### PR TITLE
Update README for android

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -4,11 +4,11 @@
 
 YogaLayout is available via jcenter:
 
-    compile 'com.facebook.yoga.android:yoga-layout:1.2.0'
+    implementation 'com.facebook.yoga.android:yoga-layout:1.16.0'
 
 ## Getting Started
 
-Check out the docs [here](https://facebook.github.io/yoga/docs/api/android/).
+Check out the docs [here](https://yogalayout.com/getting-started/standalone/).
 
 We also have a sample project.  To try it, clone the repo and run (with a device attached)
 


### PR DESCRIPTION
Install instruction and doc url seemed to be outdated.